### PR TITLE
Criação e Listagem de Usuário

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "infra/errors";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -8,6 +12,11 @@ function onNoMatchHandler(request, response) {
 function onErrorHandler(error, request, response) {
   //o try é tudo que está dentro das funções handler
   //enquanto esse código é relativo ao bloco catch que captura e trata o erro
+
+  if (error instanceof ValidationError) {
+    return response.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     statusCode: error.statusCode,
     cause: error,

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -2,6 +2,7 @@ import {
   InternalServerError,
   MethodNotAllowedError,
   ValidationError,
+  NotFoundError,
 } from "infra/errors";
 
 function onNoMatchHandler(request, response) {
@@ -13,7 +14,7 @@ function onErrorHandler(error, request, response) {
   //o try é tudo que está dentro das funções handler
   //enquanto esse código é relativo ao bloco catch que captura e trata o erro
 
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return response.status(error.statusCode).json(error);
   }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -38,6 +38,26 @@ export class ServiceError extends Error {
   }
 }
 
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um erro de validação ocorreu.", {
+      cause,
+    });
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -58,6 +58,27 @@ export class ValidationError extends Error {
   }
 }
 
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Não foi possível encontrar este recurso no sistema.", {
+      cause,
+    });
+    this.name = "NotFoundError";
+    this.action =
+      action || "Verifique se os parâmetros enviados na consulta estão certos.";
+    this.statusCode = 404;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");

--- a/infra/migrations/1732022197069_test-migration.js
+++ b/infra/migrations/1732022197069_test-migration.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1746626240060_create-users.js
+++ b/infra/migrations/1746626240060_create-users.js
@@ -1,0 +1,44 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"), //usamos o pgm para executar uma função através do método 'func'. Dentro podemos passar uma query, que nesse caso executa uma função capaz de gerar um uuid randômico.
+    },
+
+    // For reference, GitHub limits usernames to 39 characters.
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+
+    // Why 60 in length? https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+
+    // Why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+  });
+};
+
+exports.down = false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -9,7 +9,7 @@ const defaultMigrationsOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,78 @@
+import database from "infra/database.js";
+import { ValidationError } from "infra/errors.js";
+
+async function create(userInputValues) {
+  await validateUniqueEmail(userInputValues.email);
+  await validateUniqueUsername(userInputValues.username);
+
+  const newUser = await runInsertQuery(userInputValues);
+  return newUser;
+
+  async function validateUniqueEmail(email) {
+    const results = await database.query({
+      text: `
+        SELECT  
+          email
+        FROM
+          users
+        WHERE
+          LOWER(email) = LOWER($1)
+        ;`,
+      values: [email],
+    });
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function validateUniqueUsername(username) {
+    const results = await database.query({
+      text: `
+        SELECT  
+          username
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        ;`,
+      values: [username],
+    });
+
+    if (results.rowCount > 0) {
+      throw new ValidationError({
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const results = await database.query({
+      text: `
+        INSERT INTO 
+          users (username, email, password) 
+        VALUES 
+          ($1, $2, $3)
+        RETURNING
+          *
+        ;`,
+      values: [
+        userInputValues.username,
+        userInputValues.email,
+        userInputValues.password,
+      ],
+    });
+
+    return results.rows[0];
+  }
+}
+
+const user = {
+  create,
+};
+
+export default user;

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,36 @@
 import database from "infra/database.js";
-import { ValidationError } from "infra/errors.js";
+import { ValidationError, NotFoundError } from "infra/errors.js";
+
+async function findOneByUsername(username) {
+  const userFound = await runSelectQuery(username);
+
+  return userFound;
+
+  async function runSelectQuery(username) {
+    const results = await database.query({
+      text: `
+        SELECT  
+          *
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        LIMIT
+          1
+        ;`,
+      values: [username],
+    });
+
+    if (results.rowCount === 0) {
+      throw new NotFoundError({
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+      });
+    }
+
+    return results.rows[0];
+  }
+}
 
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
@@ -73,6 +104,7 @@ async function create(userInputValues) {
 
 const user = {
   create,
+  findOneByUsername,
 };
 
 export default user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "pg": "8.13.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -11062,6 +11063,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "pg": "8.13.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,16 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import user from "models/user.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers); //passamos o objeto de configuração que está presente na propriedade errorHandlers do objeto controller retornado pelo módulo que ficou responsável por encapsular essas tratativas.
+
+async function getHandler(request, response) {
+  // api/v1/users/[username]
+  const username = request.query.username;
+  const userFound = await user.findOneByUsername(username);
+  return response.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import user from "models/user.js";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers); //passamos o objeto de configuração que está presente na propriedade errorHandlers do objeto controller retornado pelo módulo que ficou responsável por encapsular essas tratativas.
+
+async function postHandler(request, response) {
+  const userInputValues = request.body;
+  const newUser = await user.create(userInputValues);
+  return response.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,103 @@
+import { version as uuidVersion } from "uuid"; //desestruturando o método version de uuid e aplicando um apelido
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "mesmo.case@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "MesmoCase",
+        email: "mesmo.case@curso.dev",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN(); //Se o valor passado no Date.parse() não for do tipo data, a função retornarar um NaN
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "CaseDiferente",
+          email: "case.diferente@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/casediferente",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "CaseDiferente",
+        email: "case.diferente@curso.dev",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      expect(uuidVersion(response2Body.id)).toBe(4);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN(); //Se o valor passado no Date.parse() não for do tipo data, a função retornarar um NaN
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/UsuarioInexistente",
+      );
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+        status_code: 404,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,121 @@
+import { version as uuidVersion } from "uuid"; //desestruturando o método version de uuid e aplicando um apelido
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "daniel",
+          email: "danielberriel163@gmail.com",
+          password: "senha123",
+        }),
+      });
+
+      expect(response.status).toBe(201); //201 (created)
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "daniel",
+        email: "danielberriel163@gmail.com",
+        password: "senha123",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN(); //Se o valor passado no Date.parse() não for do tipo data, a função retornarar um NaN
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "emailduplicado1",
+          email: "duplicado@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201); //201 (created)
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "emailduplicado2",
+          email: "Duplicado@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400); //400 (bad request)
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "usernameduplicado",
+          email: "usernameduplicado1@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201); //201 (created)
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", //indica que é um dado que será consumido por uma aplicação e especifica o formato dos dados enviados (json). Essa especificação prepara a ponta que irá receber a requisição, para que interprete o cabeçalho da maneira correta.
+        },
+        body: JSON.stringify({
+          username: "UsernameDuplicado",
+          email: "usernameduplicado2@curso.dev",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400); //400 (bad request)
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from "async-retry";
 import database from "infra/database.js";
+import migrator from "models/migrator.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -30,9 +31,14 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 };
 
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints: 
  - `POST` `/api/v1/users`
  - `GET` `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cria a tabela `users`
- Cria dois novos erros customizados:
  - `ValidationError`
  - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
  - `runPendingMigrations`
- Silencia os logs do `migrator`