### PR TITLE
Limpando cookie de sessão ao utilizar sessão expirada

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -17,11 +17,12 @@ function onErrorHandler(error, request, response) {
   //o try é tudo que está dentro das funções handler
   //enquanto esse código é relativo ao bloco catch que captura e trata o erro
 
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
     return response.status(error.statusCode).json(error);
   }
 

--- a/models/session.js
+++ b/models/session.js
@@ -63,7 +63,7 @@ async function create(userId) {
 async function renew(sessionId) {
   const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
 
-  const renewedSessionObject = runUpdateQuery(sessionId, expiresAt);
+  const renewedSessionObject = await runUpdateQuery(sessionId, expiresAt);
   return renewedSessionObject;
 
   async function runUpdateQuery(sessionId, expiresAt) {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -92,6 +92,19 @@ describe("GET /api/v1/user", () => {
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
       });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
     });
 
     test("With expired session", async () => {
@@ -122,6 +135,19 @@ describe("GET /api/v1/user", () => {
         message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
 


### PR DESCRIPTION
Esse Pull Request é composto por 2 commits:

926206c 
Este commit modifica o `controller.js` criando um caminho diferente dentro de `onErrorHandler` para o `UnauthorizedError`. Isso faz com que sempre que for lançado um `UnauthorizedError` seja devolvido um cabeçalho `Set-Cookie` que irá limpar o `session_id` que estiver no navegador. Essa modificação se mostrou necessária, pois mesmo com o cookie expirado o navegador poderia continuar guardando ele e ficar dessincronizado com o servidor.

c510f92
Esse commit adiciona um `await` que estava faltando dentro de `session.renew()`.